### PR TITLE
[#110] Post: 카테고리로 게시물 목록 조회하는 기능 수정

### DIFF
--- a/src/main/java/kr/sparta/rchive/domain/post/controller/PostController.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/controller/PostController.java
@@ -75,11 +75,13 @@ public class PostController {
             @LoginUser User user,
             @RequestParam("trackName") TrackNameEnum trackName,
             @RequestParam("period") Integer period,
-            @RequestParam("category") PostTypeEnum postType
+            @RequestParam("category") PostTypeEnum postType,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size
     ){
-        List<PostGetCategoryPostRes> responseList =
-                postTagCoreService.getPostListByCategory(user, trackName, period, postType);
-
+        Pageable pageable = new CustomPageable(page, size, Sort.unsorted());
+        Page<PostGetCategoryPostRes> responseList =
+                postTagCoreService.getPostListByCategory(user, trackName, period, postType, pageable);
         return ResponseEntity.status(PostResponseCode.OK_GET_CATEGORY_POST.getHttpStatus())
                 .body(CommonResponseDto.of(PostResponseCode.OK_GET_CATEGORY_POST, responseList));
     }

--- a/src/main/java/kr/sparta/rchive/domain/post/dto/PostSearchInfo.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/dto/PostSearchInfo.java
@@ -1,6 +1,7 @@
 package kr.sparta.rchive.domain.post.dto;
 
 import kr.sparta.rchive.domain.post.entity.Post;
+import kr.sparta.rchive.domain.post.entity.Tag;
 import lombok.Builder;
 
 import java.util.List;
@@ -8,6 +9,6 @@ import java.util.List;
 @Builder
 public record PostSearchInfo(
         Post post,
-        List<String> tagNameList
+        List<Tag> tagNameList
 ) {
 }

--- a/src/main/java/kr/sparta/rchive/domain/post/dto/response/PostGetCategoryPostRes.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/dto/response/PostGetCategoryPostRes.java
@@ -1,5 +1,6 @@
 package kr.sparta.rchive.domain.post.dto.response;
 
+import kr.sparta.rchive.domain.post.dto.TagInfo;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -10,6 +11,6 @@ public record PostGetCategoryPostRes(
         String tutor,
         String title,
         LocalDate uploadedAt,
-        List<String> tagNameList
+        List<TagInfo> tagList
 ) {
 }

--- a/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepository.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
-    List<Post> findAllByPostTypeAndTrackId(PostTypeEnum postType, Long trackId);
 
 //    @Query("select p from Post p " +
 //            "join fetch p.track t " +

--- a/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustom.java
@@ -15,4 +15,8 @@ public interface PostRepositoryCustom {
     List<Post> findPostListInBackOfficePostTypeNotNullByPM(PostTypeEnum postType, LocalDate startDate, LocalDate endDate, Integer searchPeriod, Boolean isOpened);
 
     List<Post> findPostListInBackOfficePostTypeNotNullApm(PostTypeEnum postType, LocalDate startDate, LocalDate endDate, Integer period, Boolean isOpened);
+
+    List<Post> findAllByPostTypeAndTrackIdUserRoleUser(PostTypeEnum postType, Long trackId);
+
+    List<Post> findAllByPostTypeAndTrackIdUserRoleManager(PostTypeEnum postType, Long trackId);
 }

--- a/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustomImpl.java
@@ -100,4 +100,43 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .orderBy(post.uploadedAt.desc())
                 .fetch();
     }
+
+    @Override
+    public List<Post> findAllByPostTypeAndTrackIdUserRoleUser(PostTypeEnum postType, Long trackId) {
+        QPost post = QPost.post;
+        QPostTag postTag = QPostTag.postTag;
+        QTag tag = QTag.tag;
+
+        return queryFactory
+                .select(post).distinct()
+                .from(post)
+                .leftJoin(post.postTagList, postTag).fetchJoin()
+                .leftJoin(postTag.tag, tag).fetchJoin()
+                .where(
+                        post.postType.eq(postType),
+                        post.track.id.eq(trackId),
+                        post.isOpened.eq(true)
+                )
+                .orderBy(post.uploadedAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<Post> findAllByPostTypeAndTrackIdUserRoleManager(PostTypeEnum postType, Long trackId) {
+        QPost post = QPost.post;
+        QPostTag postTag = QPostTag.postTag;
+        QTag tag = QTag.tag;
+
+        return queryFactory
+                .select(post).distinct()
+                .from(post)
+                .leftJoin(post.postTagList, postTag).fetchJoin()
+                .leftJoin(postTag.tag, tag).fetchJoin()
+                .where(
+                        post.postType.eq(postType),
+                        post.track.id.eq(trackId)
+                )
+                .orderBy(post.uploadedAt.desc())
+                .fetch();
+    }
 }

--- a/src/main/java/kr/sparta/rchive/domain/post/service/PostService.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/service/PostService.java
@@ -9,6 +9,7 @@ import kr.sparta.rchive.domain.post.exception.PostExceptionCode;
 import kr.sparta.rchive.domain.post.repository.PostRepository;
 import kr.sparta.rchive.domain.user.entity.Track;
 import kr.sparta.rchive.domain.user.enums.TrackNameEnum;
+import kr.sparta.rchive.domain.user.enums.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,7 +78,7 @@ public class PostService {
     }
 
     public List<Long> findPostIdListByPostTypeAndTrackId(PostTypeEnum postType, Long trackId) {
-        return postRepository.findAllByPostTypeAndTrackId(postType, trackId).stream()
+        return postRepository.findAllByPostTypeAndTrackIdUserRoleUser(postType, trackId).stream()
                 .map(Post::getId)
                 .collect(Collectors.toList());
     }
@@ -112,6 +113,15 @@ public class PostService {
             return postRepository.findPostListInBackOfficePostTypeNotNullByPM(postType, startDate, endDate, searchPeriod, isOpened);
         }
         return postRepository.findPostListInBackOfficePostTypeNotNullApm(postType, startDate, endDate, track.getPeriod(), isOpened);
+    }
+
+    public List<Post> findPostListByPostTypeAndTrackId(UserRoleEnum userRole, PostTypeEnum postType, Track track) {
+        if(userRole.equals(UserRoleEnum.USER)) {
+            return postRepository.findAllByPostTypeAndTrackIdUserRoleUser(postType, track.getId());
+        }
+        else {
+            return postRepository.findAllByPostTypeAndTrackIdUserRoleManager(postType, track.getId());
+        }
     }
 
 //    public Post findTest(Long postId) {


### PR DESCRIPTION
## 개요
카테고리로 게시물 목록 조회하는 기능 수정

## 작업사항
- [x] post 내용 자체를 한 번에 가져오도록 수정
- [x] 페이징 적용
- [x] TagName만 보내는게 아닌 tagId와 tagName을 보내도록 변경
 
## 관련 이슈
- [x] close #110 
