### PR TITLE
[#350] Post: 프론트 요청으로 태그 검색 시 태그 네임도 전달해 주는 방식으로 변경

### DIFF
--- a/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
+++ b/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
@@ -109,12 +109,13 @@ public class PostTagCoreService {
 
     // TODO : Redis 만들기
     public Page<PostGetRes> searchPostByTag(TrackNameEnum trackName, Integer period,
-                                                    Long tagId, User user, String tagName, Pageable pageable) {
+                                            Long tagId, User user, String tagName,
+                                            PostTypeEnum postType, Pageable pageable) {
         Track track = trackService.findTrackByTrackNameAndPeriod(trackName, period);
         Role role = userRoleAndTrackCheck(user, track);
         userCheckPermission(user.getUserRole(), track, role.getTrackRole());
 
-        List<Post> postList = postService.findPostListByTagIdWithTagList(tagId, track.getId());
+        List<Post> postList = postService.findPostListByTagIdWithTagList(tagId, track.getId(), postType);
 
         List<Long> bookmarkedPostIdList = bookmarkService.findPostIdListByUserId(user.getId());
 
@@ -182,7 +183,7 @@ public class PostTagCoreService {
 
         Tutor tutor = null;
 
-        if(request.tutorId() != null) {
+        if (request.tutorId() != null) {
             tutor = tutorService.checkTutor(request.tutorId(), managerTrack);
         }
 
@@ -288,7 +289,7 @@ public class PostTagCoreService {
         if (period == 0) {
             roleService.existByUserAndTrackByPmThrowException(user.getId(), trackName);
         } else {
-            if(!roleService.checkIsPm(user.getId(), trackName)) {
+            if (!roleService.checkIsPm(user.getId(), trackName)) {
                 roleService.existByUserAndTrackByApmThrowException(user.getId(), managerTrack.getId());
             }
         }
@@ -297,7 +298,7 @@ public class PostTagCoreService {
     }
 
     public Page<PostGetRes> searchPosts(User user, PostTypeEnum postType, TrackNameEnum trackName, Integer period,
-                                           String keyword, Long tutorId, Pageable pageable) {
+                                        String keyword, Long tutorId, Pageable pageable) {
         Track track = trackService.findTrackByTrackNameAndPeriod(trackName, period);
         Role role = userRoleAndTrackCheck(user, track);
         userCheckPermission(user.getUserRole(), track, role.getTrackRole());
@@ -464,16 +465,16 @@ public class PostTagCoreService {
 
         List<String> keywordList = redisService.getRecentSearchKeyword(user.getId(), track.getId());
 
-        if(keywordList.isEmpty()) {
+        if (keywordList.isEmpty()) {
             return null;
         }
 
         return keywordList.stream()
-            .map(
-                keyword -> PostGetRecentKeywordRes.builder()
-                    .keyword(keyword)
-                    .build()
-            ).collect(Collectors.toList());
+                .map(
+                        keyword -> PostGetRecentKeywordRes.builder()
+                                .keyword(keyword)
+                                .build()
+                ).collect(Collectors.toList());
     }
 
     public void deleteRecentSearchKeyword(User user, RecentSearchKeywordReq request) {

--- a/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
+++ b/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
@@ -109,7 +109,7 @@ public class PostTagCoreService {
 
     // TODO : Redis 만들기
     public Page<PostGetRes> searchPostByTag(TrackNameEnum trackName, Integer period,
-                                                    Long tagId, User user, Pageable pageable) {
+                                                    Long tagId, User user, String tagName, Pageable pageable) {
         Track track = trackService.findTrackByTrackNameAndPeriod(trackName, period);
         Role role = userRoleAndTrackCheck(user, track);
         userCheckPermission(user.getUserRole(), track, role.getTrackRole());
@@ -134,6 +134,7 @@ public class PostTagCoreService {
                             .uploadedAt(post.getUploadedAt())
                             .tagList(tagInfoList)
                             .isBookmarked(bookmarkedPostIdList.contains(post.getId()))
+                            .tagName(tagName)
                             .build();
                 }).collect(Collectors.toList());
 

--- a/src/main/java/kr/sparta/rchive/domain/post/controller/PostController.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/controller/PostController.java
@@ -212,12 +212,13 @@ public class PostController {
             @RequestParam("loginPeriod") Integer period,
             @RequestParam("tagId") Long tagId,
             @RequestParam("tagName") String tagName,
+            @RequestParam("postType") PostTypeEnum postType,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) {
         Pageable pageable = new CustomPageable(page, size, Sort.unsorted());
         Page<PostGetRes> responseList = postTagCoreService
-                .searchPostByTag(trackName, period, tagId, user, tagName, pageable);
+                .searchPostByTag(trackName, period, tagId, user, tagName, postType, pageable);
         return ResponseEntity.status(PostResponseCode.OK_SEARCH_POST_BY_TAG.getHttpStatus())
                 .body(CommonResponseDto.of(PostResponseCode.OK_SEARCH_POST_BY_TAG, responseList));
     }

--- a/src/main/java/kr/sparta/rchive/domain/post/controller/PostController.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/controller/PostController.java
@@ -211,12 +211,13 @@ public class PostController {
             @RequestParam("trackName") TrackNameEnum trackName,
             @RequestParam("loginPeriod") Integer period,
             @RequestParam("tagId") Long tagId,
+            @RequestParam("tagName") String tagName,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) {
         Pageable pageable = new CustomPageable(page, size, Sort.unsorted());
         Page<PostGetRes> responseList = postTagCoreService
-                .searchPostByTag(trackName, period, tagId, user, pageable);
+                .searchPostByTag(trackName, period, tagId, user, tagName, pageable);
         return ResponseEntity.status(PostResponseCode.OK_SEARCH_POST_BY_TAG.getHttpStatus())
                 .body(CommonResponseDto.of(PostResponseCode.OK_SEARCH_POST_BY_TAG, responseList));
     }

--- a/src/main/java/kr/sparta/rchive/domain/post/dto/response/PostGetRes.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/dto/response/PostGetRes.java
@@ -16,6 +16,7 @@ public record PostGetRes(
         String title,
         LocalDate uploadedAt,
         List<TagInfo> tagList,
-        Boolean isBookmarked
+        Boolean isBookmarked,
+        String tagName
 ) {
 }

--- a/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustom.java
@@ -21,7 +21,7 @@ public interface PostRepositoryCustom {
 
     List<Post> findAllByPostTypeAndTrackIdUserRoleManager(PostTypeEnum postType, Long trackId, Long tutorId);
 
-    List<Post> findPostListByTagIdAndTrackIdWithTagList(Long tagId, Long trackId);
+    List<Post> findPostListByTagIdAndTrackIdWithTagList(Long tagId, Long trackId, PostTypeEnum postType);
 
     List<Post> findPost(PostTypeEnum postType, String keyword, Long tutorId, Long trackId);
 

--- a/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/repository/PostRepositoryCustomImpl.java
@@ -186,7 +186,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public List<Post> findPostListByTagIdAndTrackIdWithTagList(Long tagId, Long trackId) {
+    public List<Post> findPostListByTagIdAndTrackIdWithTagList(Long tagId, Long trackId, PostTypeEnum postType) {
 
         QPost post = QPost.post;
         QPostTag postTag = QPostTag.postTag;
@@ -204,6 +204,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                                         .join(post.postTagList, postTag)
                                         .where(postTag.tag.id.eq(tagId))
                         ),
+                        postType != null ? post.postType.eq(postType) : null,
                         post.track.id.eq(trackId))
                 .orderBy(post.uploadedAt.desc(), post.id.desc())
                 .fetch();

--- a/src/main/java/kr/sparta/rchive/domain/post/service/PostService.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/service/PostService.java
@@ -109,8 +109,8 @@ public class PostService {
         return postRepository.findPostWithDetailByPostId(postId);
     }
 
-    public List<Post> findPostListByTagIdWithTagList(Long tagId, Long trackId) {
-        return postRepository.findPostListByTagIdAndTrackIdWithTagList(tagId, trackId);
+    public List<Post> findPostListByTagIdWithTagList(Long tagId, Long trackId, PostTypeEnum postType) {
+        return postRepository.findPostListByTagIdAndTrackIdWithTagList(tagId, trackId, postType);
     }
 
     public List<Post> findPostListByPostIdList(List<Long> postIdList) {

--- a/src/test/java/kr/sparta/rchive/domain/post/controller/PostControllerTestForUser.java
+++ b/src/test/java/kr/sparta/rchive/domain/post/controller/PostControllerTestForUser.java
@@ -311,12 +311,14 @@ public class PostControllerTestForUser implements PostTest, TutorTest, TagTest, 
         Page<PostGetRes> response = new PageImpl<>(postGetResList, pageable, 2);
 
         given(postTagCoreService.searchPostByTag(any(TrackNameEnum.class), any(Integer.class), any(Long.class),
-                any(User.class), any(Pageable.class))).willReturn(response);
+                any(User.class), any(String.class), any(PostTypeEnum.class), any(Pageable.class))).willReturn(response);
         // When - Then
         mockMvc.perform(get("/apis/v1/posts/tags/search")
                         .param("trackName", "ANDROID")
                         .param("loginPeriod", "1")
                         .param("tagId", "1")
+                        .param("tagName", "test")
+                        .param("postType", PostTypeEnum.Sparta_Lecture.name())
                         .param("page", "1")
                         .param("size", "10"))
                 .andExpectAll(

--- a/src/test/java/kr/sparta/rchive/domain/post/service/PostServiceTest.java
+++ b/src/test/java/kr/sparta/rchive/domain/post/service/PostServiceTest.java
@@ -319,9 +319,9 @@ public class PostServiceTest implements PostTest, TrackTest, TutorTest, UserTest
         // Given
         List<Post> responseList = List.of(TEST_POST_1L);
 
-        given(postRepository.findPostListByTagIdAndTrackIdWithTagList(any(Long.class), any(Long.class))).willReturn(responseList);
+        given(postRepository.findPostListByTagIdAndTrackIdWithTagList(any(Long.class), any(Long.class), any(PostTypeEnum.class))).willReturn(responseList);
         // When
-        List<Post> postList = postService.findPostListByTagIdWithTagList(1L, TEST_TRACK_ID);
+        List<Post> postList = postService.findPostListByTagIdWithTagList(1L, TEST_TRACK_ID, PostTypeEnum.Sparta_Lecture);
 
         // Then
         assertThat(postList.get(0).getTitle()).isEqualTo(responseList.get(0).getTitle());


### PR DESCRIPTION
## 개요
태그 검색 시 태그 네임도 전달해 주는 방식으로 변경

## 작업사항
- [ ] 태그 검색 시 태그 네임도 전달해 주는 방식으로 변경
 
## 관련 이슈
- [ ] close #350 
