### PR TITLE
[#401] Post: 태그 생성 시 중복 태그 생성되는 오류 수정 및 태그 내용으로 정렬하도록 변경

### DIFF
--- a/src/main/java/kr/sparta/rchive/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/kr/sparta/rchive/domain/bookmark/service/BookmarkService.java
@@ -1,5 +1,6 @@
 package kr.sparta.rchive.domain.bookmark.service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import kr.sparta.rchive.domain.bookmark.entity.Bookmark;
@@ -79,7 +80,9 @@ public class BookmarkService {
                     .map(postTag -> TagInfo.builder()
                         .tagId(postTag.getTag().getId())
                         .tagName(postTag.getTag().getTagName())
-                        .build()).collect(Collectors.toList());
+                        .build())
+                        .sorted(Comparator.comparing(TagInfo::tagName))
+                        .collect(Collectors.toList());
 
                 return PostGetRes.builder()
                     .postId(bookmark.getPost().getId())

--- a/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
+++ b/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
@@ -38,6 +38,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -83,7 +84,9 @@ public class PostTagCoreService {
                             .map(postTag -> TagInfo.builder()
                                     .tagId(postTag.getTag().getId())
                                     .tagName(postTag.getTag().getTagName())
-                                    .build()).toList();
+                                    .build())
+                            .sorted(Comparator.comparing(TagInfo::tagName))
+                            .toList();
 
                     return PostSearchBackOfficeRes.builder()
                             .postId(post.getId())
@@ -122,7 +125,9 @@ public class PostTagCoreService {
                             .map(postTag -> TagInfo.builder()
                                     .tagId(postTag.getTag().getId())
                                     .tagName(postTag.getTag().getTagName())
-                                    .build()).collect(Collectors.toList());
+                                    .build())
+                            .sorted(Comparator.comparing(TagInfo::tagName))
+                            .collect(Collectors.toList());
 
                     return PostGetRes.builder()
                             .postId(post.getId())
@@ -216,7 +221,9 @@ public class PostTagCoreService {
                 .map(postTag -> TagInfo.builder()
                         .tagId(postTag.getTag().getId())
                         .tagName(postTag.getTag().getTagName())
-                        .build()).toList();
+                        .build())
+                .sorted(Comparator.comparing(TagInfo::tagName))
+                .toList();
 
         return PostGetSinglePostRes.builder()
                 .postId(post.getId())
@@ -249,7 +256,9 @@ public class PostTagCoreService {
                             .map(postTag -> TagInfo.builder()
                                     .tagId(postTag.getTag().getId())
                                     .tagName(postTag.getTag().getTagName())
-                                    .build()).toList();
+                                    .build())
+                            .sorted(Comparator.comparing(TagInfo::tagName))
+                            .toList();
 
                     return PostGetRes.builder()
                             .postId(post.getId())
@@ -313,7 +322,9 @@ public class PostTagCoreService {
                             .map(postTag -> TagInfo.builder()
                                     .tagId(postTag.getTag().getId())
                                     .tagName(postTag.getTag().getTagName())
-                                    .build()).toList();
+                                    .build())
+                            .sorted(Comparator.comparing(TagInfo::tagName))
+                            .toList();
 
                     return PostGetRes.builder()
                             .postId(post.getId())
@@ -376,16 +387,16 @@ public class PostTagCoreService {
     }
 
     private void savePostTagByPostAndTagNameList(Post post, List<String> tagNameList) {
-        List<Tag> tagList = findTagIdListByTagNameList(tagNameList);
+        List<Tag> tagList = findTagListByTagNameList(tagNameList);
         postTagService.savePostTagByPostAndTagList(post, tagList);
     }
 
     private void updatePostTagByPostAndTagIdList(Post updatePost, List<String> tagNameList) {
-        List<Tag> tagList = findTagIdListByTagNameList(tagNameList);
+        List<Tag> tagList = findTagListByTagNameList(tagNameList);
         postTagService.updatePostTagByPostAndTag(updatePost, tagList);
     }
 
-    private List<Tag> findTagIdListByTagNameList(List<String> tagNameList) {
+    private List<Tag> findTagListByTagNameList(List<String> tagNameList) {
         return tagService.findTagIdListByTagNameList(tagNameList);
     }
 

--- a/src/main/java/kr/sparta/rchive/domain/post/service/TagService.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/service/TagService.java
@@ -1,7 +1,9 @@
 package kr.sparta.rchive.domain.post.service;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import kr.sparta.rchive.domain.post.dto.request.TagCreateReq;
 import kr.sparta.rchive.domain.post.dto.response.TagCreateRes;
@@ -41,25 +43,26 @@ public class TagService {
     public List<TagCreateRes> createTag(TagCreateReq request) {
 
         List<String> tagNameList = request.tagNameList();
+        Set<String> tagNameSet = new HashSet<>(tagNameList);
 
-        return tagNameList.stream().map(
-            tagName -> {
-                String lowerTagName = tagName.toLowerCase().trim();
+        return tagNameSet.stream().map(
+                tagName -> {
+                    String lowerTagName = tagName.toLowerCase().trim();
 
-                Tag tag = tagRepository.findByTagNameNotOptional(lowerTagName);
+                    Tag tag = tagRepository.findByTagNameNotOptional(lowerTagName);
 
-                if(!tagExist(tag)) {
-                    Tag createTag = Tag.builder()
-                        .tagName(tagName)
-                        .build();
+                    if (!tagExist(tag)) {
+                        Tag createTag = Tag.builder()
+                                .tagName(tagName)
+                                .build();
 
-                    tag = tagRepository.save(createTag);
+                        tag = tagRepository.save(createTag);
+                    }
+
+                    return TagCreateRes.builder()
+                            .tagName(tag.getTagName())
+                            .build();
                 }
-
-                return TagCreateRes.builder()
-                    .tagName(tag.getTagName())
-                    .build();
-            }
         ).collect(Collectors.toList());
     }
 

--- a/src/test/java/kr/sparta/rchive/domain/core/service/PostTagCoreServiceTest.java
+++ b/src/test/java/kr/sparta/rchive/domain/core/service/PostTagCoreServiceTest.java
@@ -77,7 +77,7 @@ public class PostTagCoreServiceTest implements UserTest, PostTest, TrackTest, Tu
         Track managerTrack = TEST_TRACK_ANDROID_PM;
         List<Post> postList = List.of(TEST_POST_1L, TEST_POST_2L);
 
-        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "id", TEST_PM_USER_ID);
         Pageable pageable = PageRequest.of(0, 10);
 
         given(trackService.findTrackByTrackNameAndPeriod(any(TrackNameEnum.class), any(Integer.class))).willReturn(managerTrack);
@@ -99,7 +99,7 @@ public class PostTagCoreServiceTest implements UserTest, PostTest, TrackTest, Tu
         Track managerTrack = TEST_TRACK_ANDROID_PM;
         List<Post> postList = List.of(TEST_POST_1L, TEST_POST_2L);
 
-        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "id", TEST_PM_USER_ID);
         Pageable pageable = PageRequest.of(0, 10);
 
         given(trackService.findTrackByTrackNameAndPeriod(any(TrackNameEnum.class), any(Integer.class))).willReturn(managerTrack);
@@ -135,7 +135,7 @@ public class PostTagCoreServiceTest implements UserTest, PostTest, TrackTest, Tu
                 .build();
 
         List<Post> postList = List.of(testPost);
-        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "id", TEST_PM_USER_ID);
         Pageable pageable = PageRequest.of(0, 10);
 
         given(trackService.findTrackByTrackNameAndPeriod(any(TrackNameEnum.class), any(Integer.class))).willReturn(managerTrack);
@@ -176,9 +176,9 @@ public class PostTagCoreServiceTest implements UserTest, PostTest, TrackTest, Tu
                 .build();
 
         List<Post> postList = List.of(testPost);
-        ReflectionTestUtils.setField(user, "id", 1L);
-        ReflectionTestUtils.setField(track, "id", 1L);
-        ReflectionTestUtils.setField(testPost, "id", 1L);
+        ReflectionTestUtils.setField(user, "id", TEST_STUDENT_ID);
+        ReflectionTestUtils.setField(track, "id", TEST_TRACK_ID);
+        ReflectionTestUtils.setField(testPost, "id", TEST_POST_1L_ID);
 
         given(trackService.findTrackByTrackNameAndPeriod(any(TrackNameEnum.class), any(Integer.class))).willReturn(track);
         given(roleService.findRoleListByUserIdAuthApprove(any(Long.class))).willReturn(roleList);


### PR DESCRIPTION
## 개요
태그 생성 시 중복 태그 생성되는 오류 수정 및 태그 내용으로 정렬하도록 변경

## 작업사항
- [ ] 태그 생성 시 중복 태그 생성되는 오류 수정
- [ ]  태그 내용으로 정렬하도록 변경
 
## 관련 이슈
- [ ] close #401 
