### PR TITLE
[#410] Post: 게시물 제목과 태그내용 공백 불가능하게 변경

### DIFF
--- a/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
+++ b/src/main/java/kr/sparta/rchive/domain/core/service/PostTagCoreService.java
@@ -13,6 +13,8 @@ import kr.sparta.rchive.domain.post.entity.Post;
 import kr.sparta.rchive.domain.post.entity.Tag;
 import kr.sparta.rchive.domain.post.entity.Tutor;
 import kr.sparta.rchive.domain.post.enums.PostTypeEnum;
+import kr.sparta.rchive.domain.post.exception.PostCustomException;
+import kr.sparta.rchive.domain.post.exception.PostExceptionCode;
 import kr.sparta.rchive.domain.post.service.PostService;
 import kr.sparta.rchive.domain.post.service.PostTagService;
 import kr.sparta.rchive.domain.post.service.TagService;
@@ -150,6 +152,12 @@ public class PostTagCoreService {
     @Transactional
     public PostCreateRes createPost(User user, TrackNameEnum trackName, Integer period, PostCreateReq request) {
 
+        String checkTitle = request.title().strip();
+
+        if(checkTitle.isEmpty()) {
+            throw new PostCustomException(PostExceptionCode.BAD_REQUEST_TITLE_EMPTY);
+        }
+
         Track managerTrack = trackService.findTrackByTrackNameAndPeriod(trackName, request.postPeriod());
 
         if (period == 0) {
@@ -172,6 +180,12 @@ public class PostTagCoreService {
     @Transactional
     public PostModifyRes updatePost(User user, TrackNameEnum trackName, Integer period, Long postId,
                                     PostUpdateReq request) {
+
+        String checkTitle = request.title().strip();
+
+        if(checkTitle.isEmpty()) {
+            throw new PostCustomException(PostExceptionCode.BAD_REQUEST_TITLE_EMPTY);
+        }
 
         PostTrackInfo postTrackInfo = checkPostAndTrack(user, trackName, period, postId);
         Post findPost = postTrackInfo.post();

--- a/src/main/java/kr/sparta/rchive/domain/post/exception/PostExceptionCode.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/exception/PostExceptionCode.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 public enum PostExceptionCode implements ExceptionCode {
     /*  400 BAD_REQUEST : 잘못된 요청  */
     BAD_REQUEST_NOT_TRACK_TUTOR(HttpStatus.BAD_REQUEST, "POST-0001", "해당 트랙의 튜터가 아님"),
+    BAD_REQUEST_TITLE_EMPTY(HttpStatus.BAD_REQUEST, "POST-0002", "제목은 공백 불가능"),
+    BAD_REQUEST_TAG_EMPTY(HttpStatus.BAD_REQUEST, "POST-0003", "태그는 공백 불가능"),
     /*  401 UNAUTHORIZED : 인증 안됨  */
 
     /*  403 FORBIDDEN : 권한 없음  */

--- a/src/main/java/kr/sparta/rchive/domain/post/service/TagService.java
+++ b/src/main/java/kr/sparta/rchive/domain/post/service/TagService.java
@@ -47,7 +47,11 @@ public class TagService {
 
         return tagNameSet.stream().map(
                 tagName -> {
-                    String lowerTagName = tagName.toLowerCase().trim();
+                    String lowerTagName = tagName.toLowerCase().strip();
+
+                    if(lowerTagName.isEmpty()) {
+                        throw new PostCustomException(PostExceptionCode.BAD_REQUEST_TAG_EMPTY);
+                    }
 
                     Tag tag = tagRepository.findByTagNameNotOptional(lowerTagName);
 


### PR DESCRIPTION
## 개요
게시물 제목과 태그내용 공백 불가능하게 변경

## 작업사항
- [x] 게시물 제목 공백 불가능하게 변경
- [x] 태그내용 공백 불가능하게 변경
 
## 관련 이슈
- [x] close #410 
